### PR TITLE
[BUGFIX] Update doesn't work with `overwrite` set to false

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -37,7 +37,7 @@ export default class Booksidian extends Plugin {
 			const shelf = new Shelf(this, _shelf.trim());
 			await shelf.createFolder();
 			await shelf.fetchGoodreadsFeed();
-			shelf.createBookFiles();
+			await shelf.createBookFiles();
 		});
 	}
 

--- a/src/Book.ts
+++ b/src/Book.ts
@@ -95,8 +95,8 @@ export class Book {
 
 		try {
 			const fs = this.plugin.app.vault.adapter;
-
-			if (fs.exists(fullName) && !this.plugin.settings.overwrite) {
+			const fileAlreadyExists = await fs.exists(fullName);
+			if (fileAlreadyExists && !this.plugin.settings.overwrite) {
 				return;
 			}
 

--- a/src/Shelf.ts
+++ b/src/Shelf.ts
@@ -44,8 +44,10 @@ export class Shelf {
 		}
 	}
 
-	public createBookFiles(): void {
-		this.getBooks().map((book) => book.createFile(book, this.path));
+	public async createBookFiles(): Promise<void> {
+		await Promise.all([
+			this.getBooks().map((book) => book.createFile(book, this.path)),
+		]);
 		this.createNotice();
 	}
 


### PR DESCRIPTION
I'm kind of new to Obsidian and saw your plugin and wanted to have a try.
I set the `overwrite` param to false, and when I launched the Booksidian sync, the notice telling me the files were created did appear but I couldn't find the files.
This PR should fix the issue.

I saw a few days ago that a maintainer was needed for the project. It seems it's no longer the case, but I'll be glad to contribute more to this cool plugin in the future.