### PR TITLE
Handle other shelves with read correctly and fix shelve reference

### DIFF
--- a/src/Book.ts
+++ b/src/Book.ts
@@ -71,8 +71,8 @@ export class Book {
 		// Goodreads doesn't send a shelf value for books on the read shelf.
 		// Infer from either a missing shelf value, or a set dateRead.
 		// Check for presence of read first in case Goodreads decides to include it.
-		if (!shelves.toLowerCase().includes("read") && (!shelves || dateRead)) {
-			return shelves ? `${this.shelves},read` : 'read';
+		if (!shelves.split(',').includes("read") && (!shelves || dateRead)) {
+			return shelves ? `${shelves},read` : 'read';
 		}
 
 		return shelves;


### PR DESCRIPTION
This PR removes a false positive detection of the `read` shelve when the word read exists in any other shelve. E.g. `export-read`.
Also the reference to `this.shelves` is not initialized yet, so it returned `undefined`. We use `shelves` directly now instead.

Btw. very cool plugin! I am setting it up for myself right now. I hope to contribute some useful features as ideas pop up.