### PR TITLE
Switched to mustache template library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
 			"version": "0.3.6",
 			"license": "MIT",
 			"dependencies": {
+				"@types/mustache": "^4.2.2",
 				"js-yaml": "^4.1.0",
+				"mustache": "^4.2.0",
 				"package.json": "^2.0.1",
 				"rss-parser": "^3.12.0",
 				"ts-jest": "^29.0.5",
@@ -1155,6 +1157,11 @@
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
 			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
 			"dev": true
+		},
+		"node_modules/@types/mustache": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.2.2.tgz",
+			"integrity": "sha512-MUSpfpW0yZbTgjekDbH0shMYBUD+X/uJJJMm9LXN1d5yjl5lCY1vN/eWKD6D1tOtjA6206K0zcIPnUaFMurdNA=="
 		},
 		"node_modules/@types/node": {
 			"version": "16.11.38",
@@ -3970,6 +3977,14 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
+		"node_modules/mustache": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+			"integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+			"bin": {
+				"mustache": "bin/mustache"
+			}
+		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6207,6 +6222,11 @@
 			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
 			"dev": true
 		},
+		"@types/mustache": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@types/mustache/-/mustache-4.2.2.tgz",
+			"integrity": "sha512-MUSpfpW0yZbTgjekDbH0shMYBUD+X/uJJJMm9LXN1d5yjl5lCY1vN/eWKD6D1tOtjA6206K0zcIPnUaFMurdNA=="
+		},
 		"@types/node": {
 			"version": "16.11.38",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.38.tgz",
@@ -8241,6 +8261,11 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"mustache": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+			"integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="
 		},
 		"natural-compare": {
 			"version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 	"devDependencies": {
 		"@types/jest": "^29.4.0",
 		"@types/node": "^16.11.6",
+		"@types/mustache": "^4.2.2",
 		"@typescript-eslint/eslint-plugin": "^5.2.0",
 		"@typescript-eslint/parser": "^5.2.0",
 		"builtin-modules": "^3.2.0",
@@ -25,6 +26,7 @@
 	},
 	"dependencies": {
 		"js-yaml": "^4.1.0",
+		"mustache": "^4.2.0",
 		"package.json": "^2.0.1",
 		"rss-parser": "^3.12.0",
 		"ts-jest": "^29.0.5",

--- a/src/Body.ts
+++ b/src/Body.ts
@@ -1,19 +1,14 @@
 import { Book } from "src/Book";
 
+// Following rssParser example to avoid issue with: import * as Mustache from 'mustache';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Mustache = require("mustache");
+
 export class Body {
-	constructor(public currentBody: string, public book: Book) {}
+	constructor(public currentBody: string, public book: Book) { }
 
 	public getBody(): string {
-		for (const key in this.book) {
-			if (this.book.hasOwnProperty(key)) {
-				const value = this.book[key as keyof Book] as string;
-				// replace all instances of the {{key}} in the current body with the value
-				this.currentBody = this.currentBody.replace(
-					new RegExp(`{{${key}}}`, "g"),
-					value
-				);
-			}
-		}
-		return this.currentBody;
+		return Mustache.render(this.currentBody, this.book);
 	}
 }


### PR DESCRIPTION
This PR switches the templating implementation to [mustache](https://github.com/janl/mustache.js) which is compatible with the current `{{dateRead}}` syntax but add many more features on top.
For example with `{{#dateRead}}Read: [[DailyNotes/{{dateRead}}]]{{/dateRead}}` it's possible to add a link to a file only if the value is set and emit nothing if not.
Mustache also supports handling [lists or repeating](https://github.com/janl/mustache.js#non-empty-lists) values in a better way.