### PR TITLE
Fix dependabot issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
 	"dependencies": {
 		"js-yaml": "^4.1.0",
 		"mustache": "^4.2.0",
-		"package.json": "^2.0.1",
 		"rss-parser": "^3.12.0",
 		"ts-jest": "^29.0.5",
 		"turndown": "^7.1.2"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"builtin-modules": "^3.2.0",
 		"esbuild": "0.13.12",
 		"jest": "^29.4.0",
-		"obsidian": "^0.12.17",
+		"obsidian": "1.5.7-1",
 		"tslib": "2.3.1",
 		"typescript": "4.4.4"
 	},


### PR DESCRIPTION
Removed the `package.json` dependency, I can't see it being used, in addition it hasn't been maintained in 4 years and npm audit + dependabot was screaming at it.

Also updated the `obsidian` dev-dependency as well as it was depending on an older version of `moment` which had issues.