### PR TITLE
Prettier formatting

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+	"trailingComma": "all",
+	"useTabs": true,
+	"semi": true,
+	"singleQuote": false,
+	"tabWidth": 4
+}

--- a/main.ts
+++ b/main.ts
@@ -16,7 +16,7 @@ export default class Booksidian extends Plugin {
 			"Booksidian Sync",
 			(evt: MouseEvent) => {
 				this.updateLibrary();
-			}
+			},
 		);
 
 		// This adds a simple command that can be triggered anywhere
@@ -45,7 +45,7 @@ export default class Booksidian extends Plugin {
 		this.settings = Object.assign(
 			{},
 			DEFAULT_SETTINGS,
-			await this.loadData()
+			await this.loadData(),
 		);
 	}
 
@@ -54,16 +54,23 @@ export default class Booksidian extends Plugin {
 	}
 
 	async configureSchedule() {
-    const minutes = parseInt(this.settings.frequency);
-    const milliseconds = minutes * 60 * 1000; // minutes * seconds * milliseconds
-    console.log('Booksidian plugin: setting interval to ', milliseconds, 'milliseconds');
-    window.clearInterval(this.scheduleInterval);
-    this.scheduleInterval = null;
-    if (!milliseconds) {
-      // we got manual option
-      return;
-    }
-    this.scheduleInterval = window.setInterval(() => this.updateLibrary(), milliseconds);
-    this.registerInterval(this.scheduleInterval);
-  }
+		const minutes = parseInt(this.settings.frequency);
+		const milliseconds = minutes * 60 * 1000; // minutes * seconds * milliseconds
+		console.log(
+			"Booksidian plugin: setting interval to ",
+			milliseconds,
+			"milliseconds",
+		);
+		window.clearInterval(this.scheduleInterval);
+		this.scheduleInterval = null;
+		if (!milliseconds) {
+			// we got manual option
+			return;
+		}
+		this.scheduleInterval = window.setInterval(
+			() => this.updateLibrary(),
+			milliseconds,
+		);
+		this.registerInterval(this.scheduleInterval);
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
 				"esbuild": "0.13.12",
 				"jest": "^29.4.0",
 				"obsidian": "1.5.7-1",
+				"prettier": "^3.2.5",
 				"tslib": "2.3.1",
 				"typescript": "4.4.4"
 			}
@@ -4055,6 +4056,21 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/prettier": {
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+			"integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+			"dev": true,
+			"bin": {
+				"prettier": "bin/prettier.cjs"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
+		},
 		"node_modules/pretty-format": {
 			"version": "29.4.0",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.4.0.tgz",
@@ -7775,6 +7791,12 @@
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true,
 			"peer": true
+		},
+		"prettier": {
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+			"integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+			"dev": true
 		},
 		"pretty-format": {
 			"version": "29.4.0",

--- a/package.json
+++ b/package.json
@@ -13,14 +13,15 @@
 	"license": "MIT",
 	"devDependencies": {
 		"@types/jest": "^29.4.0",
-		"@types/node": "^16.11.6",
 		"@types/mustache": "^4.2.2",
+		"@types/node": "^16.11.6",
 		"@typescript-eslint/eslint-plugin": "^5.2.0",
 		"@typescript-eslint/parser": "^5.2.0",
 		"builtin-modules": "^3.2.0",
 		"esbuild": "0.13.12",
 		"jest": "^29.4.0",
 		"obsidian": "1.5.7-1",
+		"prettier": "^3.2.5",
 		"tslib": "2.3.1",
 		"typescript": "4.4.4"
 	},

--- a/src/Body.ts
+++ b/src/Body.ts
@@ -6,7 +6,10 @@ import { Book } from "src/Book";
 const Mustache = require("mustache");
 
 export class Body {
-	constructor(public currentBody: string, public book: Book) { }
+	constructor(
+		public currentBody: string,
+		public book: Book,
+	) {}
 
 	public getBody(): string {
 		const render = Mustache.render(this.currentBody, this.book) as string;

--- a/src/Book.ts
+++ b/src/Book.ts
@@ -5,7 +5,7 @@ import { Body } from "./Body";
 import { Frontmatter } from "./Frontmatter";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const TurndownService = require('turndown');
+const TurndownService = require("turndown");
 
 export class Book {
 	id: string;
@@ -28,7 +28,10 @@ export class Book {
 	cover: string;
 	bookPage: string;
 
-	constructor(public plugin: Booksidian, book: GoodreadsBook) {
+	constructor(
+		public plugin: Booksidian,
+		book: GoodreadsBook,
+	) {
 		this.id = book.identifiers.$.id;
 		this.pages = parseInt(book.identifiers.num_pages[0]) || undefined;
 		this.title = this.cleanTitle(book.title, false);
@@ -37,7 +40,7 @@ export class Book {
 		this.description = this.htmlToMarkdown(book.book_description);
 		this.author = book.author;
 		this.isbn = book.isbn;
-		this.review = this.htmlToMarkdown(book.user_review || '');
+		this.review = this.htmlToMarkdown(book.user_review || "");
 		this.rating = parseInt(book.user_rating) || 0;
 		this.avgRating = parseFloat(book.average_rating) || 0;
 		this.dateAdded = this.parseDate(book.user_date_added);
@@ -65,16 +68,16 @@ export class Book {
 	}
 
 	private htmlToMarkdown(html: string) {
-		const turndownService = new TurndownService()
-		return turndownService.turndown(html)
+		const turndownService = new TurndownService();
+		return turndownService.turndown(html);
 	}
 
-	private getShelves(shelves: string, dateRead: string) : string {
+	private getShelves(shelves: string, dateRead: string): string {
 		// Goodreads doesn't send a shelf value for books on the read shelf.
 		// Infer from either a missing shelf value, or a set dateRead.
 		// Check for presence of read first in case Goodreads decides to include it.
-		if (!shelves.split(',').includes("read") && (!shelves || dateRead)) {
-			return shelves ? `${shelves},read` : 'read';
+		if (!shelves.split(",").includes("read") && (!shelves || dateRead)) {
+			return shelves ? `${shelves},read` : "read";
 		}
 
 		return shelves;
@@ -129,7 +132,7 @@ export class Book {
 		}
 
 		// replace remaining special characters with an empty character
-		title = title.replace(/[&\/\\#,+()$~%.'":*?<>{}|]/g,'');
+		title = title.replace(/[&\/\\#,+()$~%.'":*?<>{}|]/g, "");
 
 		return title.trim();
 	}

--- a/src/Frontmatter.ts
+++ b/src/Frontmatter.ts
@@ -3,10 +3,13 @@ import { CurrentYAML } from "const/settings";
 import { Book } from "src/Book";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const yaml = require('js-yaml');
+const yaml = require("js-yaml");
 
 export class Frontmatter {
-	constructor(public currentYAML: CurrentYAML, public book: Book) {}
+	constructor(
+		public currentYAML: CurrentYAML,
+		public book: Book,
+	) {}
 
 	public getFrontmatter(): string {
 		return (
@@ -19,18 +22,22 @@ export class Frontmatter {
 	}
 
 	private getFrontmatterLines(): string {
-		const output: {[key: string]: number | string | string[]} = {};
+		const output: { [key: string]: number | string | string[] } = {};
 
 		Object.keys(this.currentYAML).forEach((key: string) => {
 			const value = this.currentYAML[key];
 			const [prefix, postfix] = value.split(key);
 
 			if (key === "shelves") {
-				output[key] = this.book.shelves.split(",").sort().map((shelf) => {
-					return `${prefix}${shelf}${postfix}`;
-				});
+				output[key] = this.book.shelves
+					.split(",")
+					.sort()
+					.map((shelf) => {
+						return `${prefix}${shelf}${postfix}`;
+					});
 			} else {
-				output[key] = `${prefix}${this.book[key as keyof Book]}${postfix}`;
+				output[key] =
+					`${prefix}${this.book[key as keyof Book]}${postfix}`;
 			}
 		});
 

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -48,7 +48,7 @@ export class Settings extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Target Folder")
 			.setDesc(
-				"If you leave this empty, the books will be created in the root directory."
+				"If you leave this empty, the books will be created in the root directory.",
 			)
 			.addText((text) =>
 				text
@@ -57,14 +57,14 @@ export class Settings extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.targetFolderPath = value;
 						await this.plugin.saveSettings();
-					})
+					}),
 			);
 
 		// set the base url for all goodreads rss feeds
 		new Setting(containerEl)
 			.setName("RSS Base URL")
 			.setDesc(
-				"Please add your RSS Base URL here (everything before the shelf name)."
+				"Please add your RSS Base URL here (everything before the shelf name).",
 			)
 			.setTooltip("https://www.goodreads.com/ ... &shelf=")
 			.addText((text) =>
@@ -73,14 +73,14 @@ export class Settings extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.goodreadsBaseUrl = value;
 						await this.plugin.saveSettings();
-					})
+					}),
 			);
 
 		// set the goodreads shelves that should be exported
 		new Setting(containerEl)
 			.setName("Your Goodreads Shelves")
 			.setDesc(
-				"Here you can specify which shelves you'd like to export. Please separate the values with a comma and make sure you got the names right. "
+				"Here you can specify which shelves you'd like to export. Please separate the values with a comma and make sure you got the names right. ",
 			)
 			.setTooltip("You can check the proper naming in the RSS url.")
 			.addTextArea((text) => {
@@ -94,9 +94,11 @@ export class Settings extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
-			.setName('Configure resync frequency')
-			.setDesc('If not set to manual, Booksidian will resync with Goodreads RSS at configured interval')
-			.addDropdown(dropdown => {
+			.setName("Configure resync frequency")
+			.setDesc(
+				"If not set to manual, Booksidian will resync with Goodreads RSS at configured interval",
+			)
+			.addDropdown((dropdown) => {
 				dropdown.addOption("0", "Manual");
 				dropdown.addOption("60", "Every 1 hour");
 				dropdown.addOption((12 * 60).toString(), "Every 12 hours");
@@ -109,20 +111,22 @@ export class Settings extends PluginSettingTab {
 					this.plugin.saveSettings();
 
 					this.plugin.configureSchedule();
-				})
+				});
 			});
 
 		new Setting(containerEl)
-			.setName('Overwrite')
-			.setDesc('When syncing with Goodreads, overwrite existing notes. Modifications to notes will be lost, but changes from Goodreads will now be picked up.')
-			.addToggle(toggle => {
+			.setName("Overwrite")
+			.setDesc(
+				"When syncing with Goodreads, overwrite existing notes. Modifications to notes will be lost, but changes from Goodreads will now be picked up.",
+			)
+			.addToggle((toggle) => {
 				toggle.setValue(this.plugin.settings.overwrite);
 
 				toggle.onChange((newValue) => {
 					this.plugin.settings.overwrite = newValue;
 					this.plugin.saveSettings();
-				})
-			})
+				});
+			});
 
 		containerEl.createEl("h3", { text: "Body" });
 		containerEl.createEl("p", {
@@ -175,23 +179,32 @@ export class Settings extends PluginSettingTab {
 					.addOption("", `${this.getSelectedCount()}`)
 					.addOption("id", `${this.getDisplay("id")}`)
 					.addOption("author", `${this.getDisplay("author")}`)
-					.addOption("title", `${this.getDisplay("title", "title (formatted for filenames/links)")}`)
-					.addOption("fullTitle", `${this.getDisplay("fullTitle", "fullTitle (formatted, includes subtitle)")}`)
+					.addOption(
+						"title",
+						`${this.getDisplay("title", "title (formatted for filenames/links)")}`,
+					)
+					.addOption(
+						"fullTitle",
+						`${this.getDisplay("fullTitle", "fullTitle (formatted, includes subtitle)")}`,
+					)
 					.addOption("rawTitle", `${this.getDisplay("rawTitle")}`)
 					.addOption("subtitle", `${this.getDisplay("subtitle")}`)
 					.addOption("pages", `${this.getDisplay("pages")}`)
 					.addOption("series", `${this.getDisplay("series")}`)
-					.addOption("description", `${this.getDisplay("description")}`)
+					.addOption(
+						"description",
+						`${this.getDisplay("description")}`,
+					)
 					.addOption("cover", `${this.getDisplay("cover")}`)
 					.addOption("isbn", `${this.getDisplay("isbn")}`)
-					.addOption("review",`${this.getDisplay("review")}`)
+					.addOption("review", `${this.getDisplay("review")}`)
 					.addOption("rating", `${this.getDisplay("rating")}`)
 					.addOption("avgRating", `${this.getDisplay("avgRating")}`)
 					.addOption("dateAdded", `${this.getDisplay("dateAdded")}`)
 					.addOption("dateRead", `${this.getDisplay("dateRead")}`)
 					.addOption(
 						"datePublished",
-						`${this.getDisplay("datePublished")}`
+						`${this.getDisplay("datePublished")}`,
 					)
 					.addOption("shelves", `${this.getDisplay("shelves")}`)
 					.addOption("bookPage", `${this.getDisplay("bookPage")}`)
@@ -201,7 +214,7 @@ export class Settings extends PluginSettingTab {
 							: (this.currentYAML[value] = value);
 						await this.plugin.saveSettings();
 						this.display();
-					})
+					}),
 			)
 			.addExtraButton((button) =>
 				button
@@ -209,7 +222,7 @@ export class Settings extends PluginSettingTab {
 						this.display();
 					})
 					.setIcon("sync")
-					.setTooltip("Refresh Previews")
+					.setTooltip("Refresh Previews"),
 			);
 
 		Object.keys(this.currentYAML).forEach((key) => {
@@ -223,7 +236,7 @@ export class Settings extends PluginSettingTab {
 								if (value.startsWith("[[")) {
 									this.currentYAML[key] = value.replace(
 										/[[\]]/g,
-										""
+										"",
 									);
 								} else {
 									this.currentYAML[key] = "[[" + value + "]]";
@@ -231,7 +244,7 @@ export class Settings extends PluginSettingTab {
 								await this.plugin.saveSettings();
 								this.display();
 							})
-							.setIcon("bracket-glyph").setTooltip
+							.setIcon("bracket-glyph").setTooltip,
 				)
 				.addText((text) =>
 					text
@@ -240,7 +253,7 @@ export class Settings extends PluginSettingTab {
 						.onChange(async (value) => {
 							this.currentYAML[key] = value;
 							await this.plugin.saveSettings();
-						})
+						}),
 				)
 				.addExtraButton((button) =>
 					button
@@ -250,7 +263,7 @@ export class Settings extends PluginSettingTab {
 							this.display();
 						})
 						.setIcon("trash")
-						.setTooltip("Remove")
+						.setTooltip("Remove"),
 				);
 		});
 	}

--- a/src/Shelf.ts
+++ b/src/Shelf.ts
@@ -9,7 +9,10 @@ export class Shelf {
 	url: string;
 	books: Book[] = [];
 
-	constructor(public plugin: Booksidian, public shelfName: string) {
+	constructor(
+		public plugin: Booksidian,
+		public shelfName: string,
+	) {
 		this.path = `${plugin.settings.targetFolderPath}/`;
 		this.url = `${plugin.settings.goodreadsBaseUrl}${shelfName}`;
 	}
@@ -57,14 +60,14 @@ export class Shelf {
 		if (syncCount === 0) {
 			return;
 		}
-		
+
 		const firstTitle = this.getBooks()[0].rawTitle;
-		let noticeMsg = '';
+		let noticeMsg = "";
 
 		if (syncCount === 1) {
 			noticeMsg = `${firstTitle} synced from Goodreads!`;
 		} else {
-			noticeMsg = `${this.getBooks().length} books, including ${firstTitle}, synced from Goodreads!`
+			noticeMsg = `${this.getBooks().length} books, including ${firstTitle}, synced from Goodreads!`;
 		}
 
 		new Notice(noticeMsg, 5000);

--- a/test/BookTest.ts
+++ b/test/BookTest.ts
@@ -1,16 +1,16 @@
-import {Book} from "src/Book";
-import {GoodreadsBook} from "const/goodreads";
-import {Book_id} from "const/goodreads";
-import {Identifiers} from "const/goodreads";
+import { Book } from "src/Book";
+import { GoodreadsBook } from "const/goodreads";
+import { Book_id } from "const/goodreads";
+import { Identifiers } from "const/goodreads";
 
-const test_book_id : Book_id = {
-	id: "sample_id"
-}
+const test_book_id: Book_id = {
+	id: "sample_id",
+};
 
 const test_identifier: Identifiers = {
 	$: test_book_id,
-	num_pages: ["123"]
-}
+	num_pages: ["123"],
+};
 
 const test_book: GoodreadsBook = {
 	author: "test_author",
@@ -19,8 +19,8 @@ const test_book: GoodreadsBook = {
 	pubDate: "01/01/1970",
 	isbn: "0123456789",
 	user_rating: "5",
-  user_review: "Test review",
-  book_description: "Test description",
+	user_review: "Test review",
+	book_description: "Test description",
 	average_rating: "3",
 	user_read_at: "01/01/1970",
 	user_date_added: "01/01/1970",
@@ -31,191 +31,191 @@ const test_book: GoodreadsBook = {
 	guid: "test_guid",
 	user_shelves: "test_shelf",
 	image_url: "test_image_url",
-}
+};
 
-describe('Empty title', () => {
-  test('empty title should result in empty_string', () => {
-    // Given
-    test_book.title = ""
-    // When
-    const unit = new Book(null, test_book);
-    // Then
-    expect(unit.title).toBe("");
-  });
+describe("Empty title", () => {
+	test("empty title should result in empty_string", () => {
+		// Given
+		test_book.title = "";
+		// When
+		const unit = new Book(null, test_book);
+		// Then
+		expect(unit.title).toBe("");
+	});
 });
 
-describe('No special character title', () => {
-  test('No special character title should result in title', () => {
-    // Given
-    test_book.title = "My wonderful book"
-    // When
-    const unit = new Book(null, test_book);
-    // Then
-    expect(unit.title).toBe("My wonderful book");
-  });
+describe("No special character title", () => {
+	test("No special character title should result in title", () => {
+		// Given
+		test_book.title = "My wonderful book";
+		// When
+		const unit = new Book(null, test_book);
+		// Then
+		expect(unit.title).toBe("My wonderful book");
+	});
 });
 
-describe('Title with \'?\' character', () => {
-  test('Title with \'?\' character should have it replaced with empty char', () => {
-    // Given
-    test_book.title = "My wonderful book?"
-    // When
-    const unit = new Book(null, test_book);
-    // Then
-    expect(unit.title).toBe("My wonderful book");
-  });
+describe("Title with '?' character", () => {
+	test("Title with '?' character should have it replaced with empty char", () => {
+		// Given
+		test_book.title = "My wonderful book?";
+		// When
+		const unit = new Book(null, test_book);
+		// Then
+		expect(unit.title).toBe("My wonderful book");
+	});
 });
 
-describe('Title with \'#\' character', () => {
-  test('Title with \'#\' character should have it replaced with empty char', () => {
-    // Given
-    test_book.title = "My wonderful book#"
-    // When
-    const unit = new Book(null, test_book);
-    // Then
-    expect(unit.title).toBe("My wonderful book");
-  });
+describe("Title with '#' character", () => {
+	test("Title with '#' character should have it replaced with empty char", () => {
+		// Given
+		test_book.title = "My wonderful book#";
+		// When
+		const unit = new Book(null, test_book);
+		// Then
+		expect(unit.title).toBe("My wonderful book");
+	});
 });
 
-describe('Title with \'&\' character', () => {
-  test('Title with \'&\' character should have it replaced with empty char', () => {
-    // Given
-    test_book.title = "My wonderful book&"
-    // When
-    const unit = new Book(null, test_book);
-    // Then
-    expect(unit.title).toBe("My wonderful book");
-  });
+describe("Title with '&' character", () => {
+	test("Title with '&' character should have it replaced with empty char", () => {
+		// Given
+		test_book.title = "My wonderful book&";
+		// When
+		const unit = new Book(null, test_book);
+		// Then
+		expect(unit.title).toBe("My wonderful book");
+	});
 });
 
-describe('Title with \'{\' character', () => {
-  test('Title with \'{\' character should have it replaced with empty char', () => {
-    // Given
-    test_book.title = "My wonderful book{"
-    // When
-    const unit = new Book(null, test_book);
-    // Then
-    expect(unit.title).toBe("My wonderful book");
-  });
+describe("Title with '{' character", () => {
+	test("Title with '{' character should have it replaced with empty char", () => {
+		// Given
+		test_book.title = "My wonderful book{";
+		// When
+		const unit = new Book(null, test_book);
+		// Then
+		expect(unit.title).toBe("My wonderful book");
+	});
 });
 
-describe('Title with \'}\' character', () => {
-  test('Title with \'}\' character should have it replaced with empty char', () => {
-    // Given
-    test_book.title = "My wonderful book}"
-    // When
-    const unit = new Book(null, test_book);
-    // Then
-    expect(unit.title).toBe("My wonderful book");
-  });
+describe("Title with '}' character", () => {
+	test("Title with '}' character should have it replaced with empty char", () => {
+		// Given
+		test_book.title = "My wonderful book}";
+		// When
+		const unit = new Book(null, test_book);
+		// Then
+		expect(unit.title).toBe("My wonderful book");
+	});
 });
 
-describe('Title with \'%\' character', () => {
-  test('Title with \'%\' character should have it replaced with empty char', () => {
-    // Given
-    test_book.title = "My wonderful book%"
-    // When
-    const unit = new Book(null, test_book);
-    // Then
-    expect(unit.title).toBe("My wonderful book");
-  });
+describe("Title with '%' character", () => {
+	test("Title with '%' character should have it replaced with empty char", () => {
+		// Given
+		test_book.title = "My wonderful book%";
+		// When
+		const unit = new Book(null, test_book);
+		// Then
+		expect(unit.title).toBe("My wonderful book");
+	});
 });
 
-describe('Title with \'<\' character', () => {
-  test('Title with \'<\' character should have it replaced with empty char', () => {
-    // Given
-    test_book.title = "My wonderful book<"
-    // When
-    const unit = new Book(null, test_book);
-    // Then
-    expect(unit.title).toBe("My wonderful book");
-  });
+describe("Title with '<' character", () => {
+	test("Title with '<' character should have it replaced with empty char", () => {
+		// Given
+		test_book.title = "My wonderful book<";
+		// When
+		const unit = new Book(null, test_book);
+		// Then
+		expect(unit.title).toBe("My wonderful book");
+	});
 });
 
-describe('Title with \'>\' character', () => {
-  test('Title with \'>\' character should have it replaced with empty char', () => {
-    // Given
-    test_book.title = "My wonderful book>"
-    // When
-    const unit = new Book(null, test_book);
-    // Then
-    expect(unit.title).toBe("My wonderful book");
-  });
+describe("Title with '>' character", () => {
+	test("Title with '>' character should have it replaced with empty char", () => {
+		// Given
+		test_book.title = "My wonderful book>";
+		// When
+		const unit = new Book(null, test_book);
+		// Then
+		expect(unit.title).toBe("My wonderful book");
+	});
 });
 
-describe('Title with \'$\' character', () => {
-  test('Title with \'$\' character should have it replaced with empty char', () => {
-    // Given
-    test_book.title = "My wonderful book$"
-    // When
-    const unit = new Book(null, test_book);
-    // Then
-    expect(unit.title).toBe("My wonderful book");
-  });
+describe("Title with '$' character", () => {
+	test("Title with '$' character should have it replaced with empty char", () => {
+		// Given
+		test_book.title = "My wonderful book$";
+		// When
+		const unit = new Book(null, test_book);
+		// Then
+		expect(unit.title).toBe("My wonderful book");
+	});
 });
 
-describe('Title with \'*\' character', () => {
-  test('Title with \'*\' character should have it replaced with empty char', () => {
-    // Given
-    test_book.title = "My wonderful book*"
-    // When
-    const unit = new Book(null, test_book);
-    // Then
-    expect(unit.title).toBe("My wonderful book");
-  });
+describe("Title with '*' character", () => {
+	test("Title with '*' character should have it replaced with empty char", () => {
+		// Given
+		test_book.title = "My wonderful book*";
+		// When
+		const unit = new Book(null, test_book);
+		// Then
+		expect(unit.title).toBe("My wonderful book");
+	});
 });
 
-describe('Title with \'|\' character', () => {
-  test('Title with \'|\' character should have it replaced with empty char', () => {
-    // Given
-    test_book.title = "My wonderful book|"
-    // When
-    const unit = new Book(null, test_book);
-    // Then
-    expect(unit.title).toBe("My wonderful book");
-  });
+describe("Title with '|' character", () => {
+	test("Title with '|' character should have it replaced with empty char", () => {
+		// Given
+		test_book.title = "My wonderful book|";
+		// When
+		const unit = new Book(null, test_book);
+		// Then
+		expect(unit.title).toBe("My wonderful book");
+	});
 });
 
-describe('Title with \'\\\' character', () => {
-  test('Title with \'\\\' character should have it replaced with empty char', () => {
-    // Given
-    test_book.title = "My wonderful book\\"
-    // When
-    const unit = new Book(null, test_book);
-    // Then
-    expect(unit.title).toBe("My wonderful book");
-  });
+describe("Title with '\\' character", () => {
+	test("Title with '\\' character should have it replaced with empty char", () => {
+		// Given
+		test_book.title = "My wonderful book\\";
+		// When
+		const unit = new Book(null, test_book);
+		// Then
+		expect(unit.title).toBe("My wonderful book");
+	});
 });
 
-describe('Title with \'\/\' character', () => {
-  test('Title with \'\/\' character should have it replaced with empty char', () => {
-    // Given
-    test_book.title = "My wonderful book\/"
-    // When
-    const unit = new Book(null, test_book);
-    // Then
-    expect(unit.title).toBe("My wonderful book");
-  });
+describe("Title with '/' character", () => {
+	test("Title with '/' character should have it replaced with empty char", () => {
+		// Given
+		test_book.title = "My wonderful book/";
+		// When
+		const unit = new Book(null, test_book);
+		// Then
+		expect(unit.title).toBe("My wonderful book");
+	});
 });
 
-describe('Title with \':\' character', () => {
-  test('Title with \':\' character should have it replaced with empty char', () => {
-    // Given
-    test_book.title = "My wonderful book:"
-    // When
-    const unit = new Book(null, test_book);
-    // Then
-    expect(unit.title).toBe("My wonderful book");
-  });
+describe("Title with ':' character", () => {
+	test("Title with ':' character should have it replaced with empty char", () => {
+		// Given
+		test_book.title = "My wonderful book:";
+		// When
+		const unit = new Book(null, test_book);
+		// Then
+		expect(unit.title).toBe("My wonderful book");
+	});
 });
 
-describe('Title with \'\"\' character', () => {
-  test('Title with \'\"\' character should have it replaced with empty char', () => {
-    // Given
-    test_book.title = "My wonderful book\""
-    // When
-    const unit = new Book(null, test_book);
-    // Then
-    expect(unit.title).toBe("My wonderful book");
-  });
+describe("Title with '\"' character", () => {
+	test("Title with '\"' character should have it replaced with empty char", () => {
+		// Given
+		test_book.title = 'My wonderful book"';
+		// When
+		const unit = new Book(null, test_book);
+		// Then
+		expect(unit.title).toBe("My wonderful book");
+	});
 });


### PR DESCRIPTION
Changes:
* added prettier as dev-dependency
* initial formatting with default prettier
* added .prettierrc
  trying to match the existing code style as much as possible

Summary:
There were some inconsistencies (e.g single-quotes vs double-quotes, missing commas / semi-colons etc) in the codebase.
The least amount of change won out and as such tabs won over spaces and double quotes won over single quotes :sweat_smile: 
I tried to match the existing code style as closely as possible then created a `.prettierrc` file to match it.

This should make is easier for contributions in the future to only include relevant changes instead of different code styles.

Adding you @MichaBrugger as reviewer just so you're aware.