### PR TITLE
Add support for absolute paths for target folder

### DIFF
--- a/src/Book.ts
+++ b/src/Book.ts
@@ -96,7 +96,7 @@ export class Book {
 
 	public async createFile(book: Book, path: string): Promise<void> {
 		const fileName = this.getBody(this.plugin.settings.fileName);
-		const fullPath = `${path}${fileName}.md`;
+		const fullPath = `${path}/${fileName}.md`;
 
 		try {
 			const fs = this.plugin.app.vault.adapter;

--- a/src/Book.ts
+++ b/src/Book.ts
@@ -3,6 +3,7 @@ import { GoodreadsBook } from "const/goodreads";
 import Booksidian from "main";
 import { Body } from "./Body";
 import { Frontmatter } from "./Frontmatter";
+import * as nodeFs from "fs";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const TurndownService = require("turndown");
@@ -98,12 +99,12 @@ export class Book {
 		const fileName = this.getBody(this.plugin.settings.fileName);
 		const fullPath = `${path}/${fileName}.md`;
 
+		// Early return if file exist and overwrite is disabled.
+		if (nodeFs.existsSync(fullPath) && !this.plugin.settings.overwrite)
+			return;
+
 		try {
 			const fs = this.plugin.app.vault.adapter;
-			const fileAlreadyExists = await fs.exists(fullPath);
-			if (fileAlreadyExists && !this.plugin.settings.overwrite) {
-				return;
-			}
 
 			// Either create new file or overwrite one that exists.
 			await fs.write(fullPath, book.getContent());

--- a/src/Book.ts
+++ b/src/Book.ts
@@ -3,6 +3,7 @@ import { GoodreadsBook } from "const/goodreads";
 import Booksidian from "main";
 import { Body } from "./Body";
 import { Frontmatter } from "./Frontmatter";
+import { isAbsolute } from "path";
 import * as nodeFs from "fs";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -99,17 +100,19 @@ export class Book {
 		const fileName = this.getBody(this.plugin.settings.fileName);
 		const fullPath = `${path}/${fileName}.md`;
 
-		// Early return if file exist and overwrite is disabled.
-		if (nodeFs.existsSync(fullPath) && !this.plugin.settings.overwrite)
-			return;
+		const bookContent = book.getContent();
 
-		try {
-			const fs = this.plugin.app.vault.adapter;
-
-			// Either create new file or overwrite one that exists.
-			await fs.write(fullPath, book.getContent());
-		} catch (error) {
-			console.log(`Error writing ${fullPath}`, error);
+		if (isAbsolute(fullPath)) {
+			nodeFs.writeFile(fullPath, bookContent, (error) => {
+				if (error) console.log(`Error writing ${fullPath}`, error);
+			});
+		} else {
+			try {
+				const fs = this.plugin.app.vault.adapter;
+				await fs.write(fullPath, bookContent);
+			} catch (error) {
+				console.log(`Error writing ${fullPath}`, error);
+			}
 		}
 	}
 

--- a/src/Book.ts
+++ b/src/Book.ts
@@ -96,19 +96,19 @@ export class Book {
 
 	public async createFile(book: Book, path: string): Promise<void> {
 		const fileName = this.getBody(this.plugin.settings.fileName);
-		const fullName = `${path}${fileName}.md`;
+		const fullPath = `${path}${fileName}.md`;
 
 		try {
 			const fs = this.plugin.app.vault.adapter;
-			const fileAlreadyExists = await fs.exists(fullName);
+			const fileAlreadyExists = await fs.exists(fullPath);
 			if (fileAlreadyExists && !this.plugin.settings.overwrite) {
 				return;
 			}
 
 			// Either create new file or overwrite one that exists.
-			await fs.write(fullName, book.getContent());
+			await fs.write(fullPath, book.getContent());
 		} catch (error) {
-			console.log(`Error writing ${fullName}`, error);
+			console.log(`Error writing ${fullPath}`, error);
 		}
 	}
 

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -48,7 +48,7 @@ export class Settings extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Target Folder")
 			.setDesc(
-				"If you leave this empty, the books will be created in the root directory.",
+				"Path to where to store the book notes. Can be either a relative path within the vault, or absolute outside of the vault. If you leave this empty, the books will be created in the root directory.",
 			)
 			.addText((text) =>
 				text

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -55,7 +55,10 @@ export class Settings extends PluginSettingTab {
 					.setPlaceholder("")
 					.setValue(this.plugin.settings.targetFolderPath)
 					.onChange(async (value) => {
-						this.plugin.settings.targetFolderPath = value;
+						this.plugin.settings.targetFolderPath = value.replace(
+							/[\\/]+$/g, // matches any trailing slashes
+							"",
+						);
 						await this.plugin.saveSettings();
 					}),
 			);

--- a/src/Shelf.ts
+++ b/src/Shelf.ts
@@ -3,6 +3,8 @@ import { GoodreadsBook } from "const/goodreads";
 import { Book } from "./Book";
 import Booksidian from "main";
 import { Notice } from "obsidian";
+import * as nodeFs from "fs";
+import { isAbsolute } from "path";
 
 export class Shelf {
 	path: string;
@@ -27,11 +29,17 @@ export class Shelf {
 
 	// create folder for each shelf (based on targetFolderPath)
 	public async createFolder(): Promise<void> {
-		try {
-			await this.plugin.app.vault.createFolder(this.path);
-		} catch (e) {
-			if (e.message.includes("already exists")) return;
-			console.warn(e);
+		if (isAbsolute(this.path)) {
+			nodeFs.mkdir(this.path, { recursive: true }, (err) => {
+				if (err) console.log(err);
+			});
+		} else {
+			try {
+				await this.plugin.app.vault.createFolder(this.path);
+			} catch (e) {
+				if (e.message.includes("already exists")) return;
+				console.warn(e);
+			}
 		}
 	}
 

--- a/src/Shelf.ts
+++ b/src/Shelf.ts
@@ -13,7 +13,7 @@ export class Shelf {
 		public plugin: Booksidian,
 		public shelfName: string,
 	) {
-		this.path = `${plugin.settings.targetFolderPath}/`;
+		this.path = `${plugin.settings.targetFolderPath}`;
 		this.url = `${plugin.settings.goodreadsBaseUrl}${shelfName}`;
 	}
 


### PR DESCRIPTION
The following PR adds support for absolute paths.

* renamed fullName to fullPath
* strip of any trailing slashes from path
* added slash in fullPath
* removed trailing slashfrom Shelf.path
* early return in case folder exist and overwrite is disabled
* added check if path is absolute and use node:mkdir to create folder if it is
* added check if fullPath is absolute and use node:fs to write the file if it is
* Updated description for the Target Folder setting