### PR TITLE
Add release notes to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
           release_name: ${{ github.ref }}
           draft: false
           prerelease: false
+          generateReleaseNotes: true
 
       - name: Upload zip file
         id: upload-zip


### PR DESCRIPTION
This PR enables `generateReleaseNotes` on the `create-release` action which will add each PR to the release notes.
