### PR TITLE
Update goodreads url use lowercase shelf names

### DIFF
--- a/src/Shelf.ts
+++ b/src/Shelf.ts
@@ -16,7 +16,7 @@ export class Shelf {
 		public shelfName: string,
 	) {
 		this.path = `${plugin.settings.targetFolderPath}`;
-		this.url = `${plugin.settings.goodreadsBaseUrl}${shelfName}`;
+		this.url = `${plugin.settings.goodreadsBaseUrl}${shelfName.toLocaleLowerCase()}`;
 	}
 
 	private setBook(book: Book): void {


### PR DESCRIPTION
This PR makes it so that the shelf names used when fetching book notes are all lower-case, this reduces the chance of using wrong shelf names.
