### PR TITLE
Fixed check for file creation and overwrite

### DIFF
--- a/src/Book.ts
+++ b/src/Book.ts
@@ -97,10 +97,11 @@ export class Book {
 	}
 
 	public async createFile(book: Book, path: string): Promise<void> {
-		if (!this.plugin.settings.overwrite) return;
-
 		const fileName = this.getBody(this.plugin.settings.fileName);
 		const fullPath = `${path}/${fileName}.md`;
+
+		const file = this.plugin.app.vault.getFileByPath(fullPath);
+		if (file && !this.plugin.settings.overwrite) return;
 
 		const bookContent = book.getContent();
 


### PR DESCRIPTION
In the previous fix for #46 I had forgotten to add a check for if the file already existed and only then overwrite the content if the user had enabled that setting.

This is now fixed.

Fixes #46 