### PR TITLE
Make the "RSS Base URL" field only save the relevant parts of the URL

### DIFF
--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -75,7 +75,7 @@ export class Settings extends PluginSettingTab {
 					.setValue(this.plugin.settings.goodreadsBaseUrl)
 					.onChange(async (value) => {
 						const validPattern =
-							/^https?:\/\/.*?\/review\/list_rss\/\d+\?key=[a-zA-Z0-9-_]+/;
+							/^https?:\/\/.*?\/review\/list_rss\/\d+\?key=[a-zA-Z0-9-_]+&shelf=/;
 
 						const result = value.match(validPattern);
 

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -79,11 +79,14 @@ export class Settings extends PluginSettingTab {
 
 						const result = value.match(validPattern);
 
+						// Save the url only when it matches the pattern
 						if (result) {
-							// Save only the url up to and including the key
 							this.plugin.settings.goodreadsBaseUrl = result[0];
-							await this.plugin.saveSettings();
+						} else {
+							this.plugin.settings.goodreadsBaseUrl = "";
 						}
+
+						await this.plugin.saveSettings();
 					}),
 			);
 

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -82,7 +82,7 @@ export class Settings extends PluginSettingTab {
 						// Save the url only when it matches the pattern
 						if (result) {
 							this.plugin.settings.goodreadsBaseUrl = result[0];
-						} else {
+						} else if (value.trim().length === 0) {
 							this.plugin.settings.goodreadsBaseUrl = "";
 						}
 

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -74,8 +74,16 @@ export class Settings extends PluginSettingTab {
 				text
 					.setValue(this.plugin.settings.goodreadsBaseUrl)
 					.onChange(async (value) => {
-						this.plugin.settings.goodreadsBaseUrl = value;
-						await this.plugin.saveSettings();
+						const validPattern =
+							/^https?:\/\/.*?\/review\/list_rss\/\d+\?key=[a-zA-Z0-9-_]+/;
+
+						const result = value.match(validPattern);
+
+						if (result) {
+							// Save only the url up to and including the key
+							this.plugin.settings.goodreadsBaseUrl = result[0];
+							await this.plugin.saveSettings();
+						}
 					}),
 			);
 

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -90,6 +90,7 @@ export class Settings extends PluginSettingTab {
 							if (result) {
 								this.plugin.settings.goodreadsBaseUrl =
 									result[0];
+								text.inputEl.value = result[0];
 							} else if (value.trim().length === 0) {
 								this.plugin.settings.goodreadsBaseUrl = "";
 							} else {

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -73,6 +73,7 @@ export class Settings extends PluginSettingTab {
 			.addText((text) =>
 				text
 					.setValue(this.plugin.settings.goodreadsBaseUrl)
+					.setPlaceholder("https://www.goodreads.com/ ... &shelf=")
 					.onChange(async (value) => {
 						const validPattern =
 							/^https?:\/\/.*?\/review\/list_rss\/\d+\?key=[a-zA-Z0-9-_]+&shelf=/;

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -77,7 +77,7 @@ export class Settings extends PluginSettingTab {
 						const validPattern =
 							/^https?:\/\/.*?\/review\/list_rss\/\d+\?key=[a-zA-Z0-9-_]+&shelf=/;
 
-						const result = value.match(validPattern);
+						const result = value.trim().match(validPattern);
 
 						// Save the url only when it matches the pattern
 						if (result) {

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -70,9 +70,8 @@ export class Settings extends PluginSettingTab {
 				"Please add your RSS Base URL here (everything before the shelf name).",
 			)
 			.setTooltip("https://www.goodreads.com/ ... &shelf=")
-			.addText((text) =>
-				text
-					.setValue(this.plugin.settings.goodreadsBaseUrl)
+			.addText((text) => {
+				text.setValue(this.plugin.settings.goodreadsBaseUrl)
 					.setPlaceholder("https://www.goodreads.com/ ... &shelf=")
 					.onChange(async (value) => {
 						const validPattern =
@@ -88,8 +87,10 @@ export class Settings extends PluginSettingTab {
 						}
 
 						await this.plugin.saveSettings();
-					}),
-			);
+					});
+				text.inputEl.style.minWidth = "18rem";
+				text.inputEl.style.maxWidth = "18rem";
+			});
 
 		// set the goodreads shelves that should be exported
 		new Setting(containerEl)

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -1,5 +1,11 @@
-import { App, Notice, PluginSettingTab, Setting } from "obsidian";
+import { App, debounce, Notice, PluginSettingTab, Setting } from "obsidian";
 import Booksidian from "../main";
+
+const debouncedSaveSettings = debounce(
+	(callback: () => void) => callback(),
+	500,
+	true,
+);
 
 export class Settings extends PluginSettingTab {
 	plugin: Booksidian;
@@ -74,24 +80,27 @@ export class Settings extends PluginSettingTab {
 				text.setValue(this.plugin.settings.goodreadsBaseUrl)
 					.setPlaceholder("https://www.goodreads.com/ ... &shelf=")
 					.onChange(async (value) => {
-						const validPattern =
-							/^https?:\/\/.*?\/review\/list_rss\/\d+\?key=[a-zA-Z0-9-_]+&shelf=/;
+						debouncedSaveSettings(async () => {
+							const validPattern =
+								/^https?:\/\/.*?\/review\/list_rss\/\d+\?key=[a-zA-Z0-9-_]+&shelf=/;
 
-						const result = value.trim().match(validPattern);
+							const result = value.trim().match(validPattern);
 
-						// Save the url only when it matches the pattern
-						if (result) {
-							this.plugin.settings.goodreadsBaseUrl = result[0];
-						} else if (value.trim().length === 0) {
-							this.plugin.settings.goodreadsBaseUrl = "";
-						} else {
-							new Notice(
-								"Booksidian: Could not parse RSS Base URL",
-							);
-							return;
-						}
+							// Save the url only when it matches the pattern
+							if (result) {
+								this.plugin.settings.goodreadsBaseUrl =
+									result[0];
+							} else if (value.trim().length === 0) {
+								this.plugin.settings.goodreadsBaseUrl = "";
+							} else {
+								new Notice(
+									"Booksidian: Could not parse RSS Base URL",
+								);
+								return;
+							}
 
-						await this.plugin.saveSettings();
+							await this.plugin.saveSettings();
+						});
 					});
 				text.inputEl.style.minWidth = "18rem";
 				text.inputEl.style.maxWidth = "18rem";

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -1,4 +1,4 @@
-import { App, PluginSettingTab, Setting } from "obsidian";
+import { App, Notice, PluginSettingTab, Setting } from "obsidian";
 import Booksidian from "../main";
 
 export class Settings extends PluginSettingTab {
@@ -84,6 +84,11 @@ export class Settings extends PluginSettingTab {
 							this.plugin.settings.goodreadsBaseUrl = result[0];
 						} else if (value.trim().length === 0) {
 							this.plugin.settings.goodreadsBaseUrl = "";
+						} else {
+							new Notice(
+								"Booksidian: Could not parse RSS Base URL",
+							);
+							return;
 						}
 
 						await this.plugin.saveSettings();


### PR DESCRIPTION
This PR makes it so that only the relevant parts of the RSS URL is captured and saved.

The pattern we match against accepts the following characters as part of the key: `a-z`, `A-Z`, `0-9`, `-` and `_`
Full pattern with comments:
```js
/^https?:\/\/.*?\/review\/list_rss\/\d+\?key=[a-zA-Z0-9-_]+&shelf=/
//    ^                              ^             ^ will match only the key and `&shelf=`, the rest will be omitted
//    |                              \ any length of digits is to be assumed to be the user id
//    \ match any URL except for the route (helpful during testing)
```

As an example, the following URL:
`https://www.goodreads.com/review/list_rss/0123456789?key=QfaK3KeyyFaKe8Uo3UMJoJt-FGhGsFaKe93CFaKeuc_DFG-e&shelf=to-read`
Would make it so that the following would be saved:
`https://www.goodreads.com/review/list_rss/0123456789?key=QfaK3KeyyFaKe8Uo3UMJoJt-FGhGsFaKe93CFaKeuc_DFG-e&shelf=`

~~This will not be reflected immediately, instead it is shown once the user navigates out of the plugin settings and back in.~~
The text input will be updated using a 500ms debounce, where the user will be notified if the URL is not valid.
If the URL is valid, the text input will be updated to reflect the corrected URL.

I put together a quick recording showing this in action.
https://www.youtube.com/watch?v=L1mG1xHH0Ew
The first URL is used to shows the notification the user will get when an invalid URL is entered.
The second is to show how the URL will be after the shelves have been stripped off.

The input field has been updated with a placeholder value to show the expected pattern
![image](https://github.com/user-attachments/assets/811358f4-287e-43d2-a3cc-bc46e081ad9e)


Fixes #40 