### PR TITLE
Fix shelf parsing function to remove spaces

### DIFF
--- a/src/Book.ts
+++ b/src/Book.ts
@@ -23,7 +23,7 @@ export class Book {
 	review: string;
 	rating: number;
 	avgRating: number;
-	shelves: string;
+	shelves: string[];
 	dateAdded: string;
 	dateRead: string;
 	datePublished: string;
@@ -74,7 +74,7 @@ export class Book {
 		return turndownService.turndown(html);
 	}
 
-	private getShelves(shelves: string, dateRead: string): string {
+	private getShelves(shelves: string, dateRead: string): string[] {
 		// Goodreads doesn't send a shelf value for books on the read shelf.
 		// Infer from either a missing shelf value, or a set dateRead.
 		// Check for presence of read first in case Goodreads decides to include it.
@@ -87,7 +87,7 @@ export class Book {
 		if (dateRead && !outputShelves.contains("read"))
 			outputShelves.push("read");
 
-		return outputShelves.join(",");
+		return outputShelves;
 	}
 
 	private getBody(currentBody: string): string {

--- a/src/Book.ts
+++ b/src/Book.ts
@@ -78,11 +78,16 @@ export class Book {
 		// Goodreads doesn't send a shelf value for books on the read shelf.
 		// Infer from either a missing shelf value, or a set dateRead.
 		// Check for presence of read first in case Goodreads decides to include it.
-		if (!shelves.split(",").includes("read") && (!shelves || dateRead)) {
-			return shelves ? `${shelves},read` : "read";
-		}
+		const outputShelves = shelves
+			.split(",")
+			.map((shelf) => shelf.trim()) // trim shelf names
+			.filter((shelf) => shelf); // filter out empty shelf names
 
-		return shelves;
+		// If the book has a read date and the `read` shelf is missing, we add it
+		if (dateRead && !outputShelves.contains("read"))
+			outputShelves.push("read");
+
+		return outputShelves.join(",");
 	}
 
 	private getBody(currentBody: string): string {

--- a/src/Frontmatter.ts
+++ b/src/Frontmatter.ts
@@ -29,12 +29,9 @@ export class Frontmatter {
 			const [prefix, postfix] = value.split(key);
 
 			if (key === "shelves") {
-				output[key] = this.book.shelves
-					.split(",")
-					.sort()
-					.map((shelf) => {
-						return `${prefix}${shelf}${postfix}`;
-					});
+				output[key] = this.book.shelves.sort().map((shelf) => {
+					return `${prefix}${shelf}${postfix}`;
+				});
 			} else {
 				output[key] =
 					`${prefix}${this.book[key as keyof Book]}${postfix}`;


### PR DESCRIPTION
The parsing function to get the shelves for each book did not trim out any whitespace.
This PR fixes this by simplifying the check.
It now splits the shelves on `,`, trims each element and removes empty shelves.
It then adds on the `read` shelf if the book has a Read Date.

This now allows users to prefix the shelves in the frontmatter etc to link to notes.
Example 
![image](https://github.com/user-attachments/assets/bf7808d1-a5b3-4444-bd5a-df1699c094ff)


The PR also changes `Book.shelves` from `string` to `string[]`