### PR TITLE
Add support for downloading cover images

### DIFF
--- a/const/goodreads.ts
+++ b/const/goodreads.ts
@@ -17,6 +17,7 @@ export interface GoodreadsBook {
 	guid: string;
 	user_shelves: string;
 	image_url: string;
+	image_path: string;
 }
 
 export interface Identifiers {

--- a/const/settings.ts
+++ b/const/settings.ts
@@ -8,6 +8,7 @@ export interface BooksidianSettings {
 	frequency: string;
 	overwrite: boolean;
 	coverDownload: boolean;
+	coverDownloadLocation: string;
 }
 
 export interface CurrentYAML {
@@ -24,4 +25,5 @@ export const DEFAULT_SETTINGS: BooksidianSettings = {
 	frequency: "0", // manual
 	overwrite: false,
 	coverDownload: false,
+	coverDownloadLocation: "",
 };

--- a/const/settings.ts
+++ b/const/settings.ts
@@ -7,6 +7,7 @@ export interface BooksidianSettings {
 	bodyString: string;
 	frequency: string;
 	overwrite: boolean;
+	coverDownload: boolean;
 }
 
 export interface CurrentYAML {
@@ -22,4 +23,5 @@ export const DEFAULT_SETTINGS: BooksidianSettings = {
 	bodyString: "# {{title}}\n\nauthor::[[{{author}}]]",
 	frequency: "0", // manual
 	overwrite: false,
+	coverDownload: false,
 };

--- a/src/Book.ts
+++ b/src/Book.ts
@@ -3,8 +3,7 @@ import { GoodreadsBook } from "const/goodreads";
 import Booksidian from "main";
 import { Body } from "./Body";
 import { Frontmatter } from "./Frontmatter";
-import { isAbsolute } from "path";
-import * as nodeFs from "fs";
+import { writeFile } from "./helpers";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const TurndownService = require("turndown");
@@ -112,18 +111,7 @@ export class Book {
 
 		const bookContent = book.getContent();
 
-		if (isAbsolute(fullPath)) {
-			nodeFs.writeFile(fullPath, bookContent, (error) => {
-				if (error) console.log(`Error writing ${fullPath}`, error);
-			});
-		} else {
-			try {
-				const fs = this.plugin.app.vault.adapter;
-				await fs.write(fullPath, bookContent);
-			} catch (error) {
-				console.log(`Error writing ${fullPath}`, error);
-			}
-		}
+		writeFile(fullPath, bookContent, this.plugin.app);
 	}
 
 	private cleanTitle(title: string, full: boolean) {

--- a/src/Book.ts
+++ b/src/Book.ts
@@ -29,6 +29,7 @@ export class Book {
 	dateRead: string;
 	datePublished: string;
 	cover: string;
+	coverImage: string;
 	bookPage: string;
 
 	constructor(
@@ -50,6 +51,7 @@ export class Book {
 		this.dateRead = this.parseDate(book.user_read_at);
 		this.datePublished = this.parseDate(book.book_published);
 		this.cover = book.image_url;
+		this.coverImage = book.image_path;
 		this.shelves = this.getShelves(book.user_shelves, this.dateRead);
 		this.bookPage = `https://www.goodreads.com/book/show/${this.id}`;
 	}

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -159,6 +159,21 @@ export class Settings extends PluginSettingTab {
 				});
 			});
 
+		containerEl.createEl("h4", { text: "Book covers" });
+
+		new Setting(containerEl)
+			.setName("Download covers")
+			.setDesc(
+				"Whether the cover image for each book should be downloaded",
+			)
+			.addToggle((toggle) => {
+				toggle.setValue(this.plugin.settings.coverDownload);
+				toggle.onChange(
+					async (value) =>
+						(this.plugin.settings.coverDownload = value),
+				);
+			});
+
 		containerEl.createEl("h3", { text: "Body" });
 		containerEl.createEl("p", {
 			text: "You can specify the content of the book-note by using {{placeholders}}. You can see the full list of placeholders in the dropdown of the frontmatter. You can choose the frontmatter placeholders you'd like and apply specific formatting to each of them.",

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -276,9 +276,14 @@ export class Settings extends PluginSettingTab {
 					.addOption("shelves", `${this.getDisplay("shelves")}`)
 					.addOption("bookPage", `${this.getDisplay("bookPage")}`)
 					.onChange(async (value: string) => {
-						this.optionIsSelected(value)
-							? delete this.currentYAML[value]
-							: (this.currentYAML[value] = value);
+						if (this.optionIsSelected(value)) {
+							delete this.currentYAML[value];
+						} else {
+							if (value === "coverImage")
+								// we want coverImage to default to a link
+								this.currentYAML[value] = `[[${value}]]`;
+							else this.currentYAML[value] = value;
+						}
 						await this.plugin.saveSettings();
 						this.display();
 					}),

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -177,7 +177,7 @@ export class Settings extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Cover download folder")
 			.setDesc(
-				'Path to where the cover images should be downloaded to. Like Target Folder, the path can be relative to the vault or absolute outside of the vault. If you leave this empty, a folder named "cover" will created under in Target Folder.',
+				'Path to where the cover images should be downloaded to. Like Target Folder, the path can be relative to the vault or absolute outside of the vault. If left empty, a folder named "cover" will be created under Target Folder.',
 			)
 			.addText((text) => {
 				text.setPlaceholder("Target Folder/cover");

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -177,10 +177,10 @@ export class Settings extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Cover download folder")
 			.setDesc(
-				"Path to where the cover images should be downloaded to. Like Target Folder, the path can be relative to the vault or absolute outside of the vault. If you leave this empty, the target folder for the books will be used.",
+				'Path to where the cover images should be downloaded to. Like Target Folder, the path can be relative to the vault or absolute outside of the vault. If you leave this empty, a folder named "cover" will created under in Target Folder.',
 			)
 			.addText((text) => {
-				text.setPlaceholder("Using Target Folder");
+				text.setPlaceholder("Target Folder/cover");
 
 				text.setValue(this.plugin.settings.coverDownloadLocation);
 				text.onChange(async (value) => {

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -174,6 +174,21 @@ export class Settings extends PluginSettingTab {
 				);
 			});
 
+		new Setting(containerEl)
+			.setName("Cover download folder")
+			.setDesc(
+				"Path to where the cover images should be downloaded to. Like Target Folder, the path can be relative to the vault or absolute outside of the vault. If you leave this empty, the target folder for the books will be used.",
+			)
+			.addText((text) => {
+				text.setPlaceholder("Using Target Folder");
+
+				text.setValue(this.plugin.settings.coverDownloadLocation);
+				text.onChange(async (value) => {
+					this.plugin.settings.coverDownloadLocation = value.trim();
+					await this.plugin.saveSettings();
+				});
+			});
+
 		containerEl.createEl("h3", { text: "Body" });
 		containerEl.createEl("p", {
 			text: "You can specify the content of the book-note by using {{placeholders}}. You can see the full list of placeholders in the dropdown of the frontmatter. You can choose the frontmatter placeholders you'd like and apply specific formatting to each of them.",

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -262,6 +262,7 @@ export class Settings extends PluginSettingTab {
 						`${this.getDisplay("description")}`,
 					)
 					.addOption("cover", `${this.getDisplay("cover")}`)
+					.addOption("coverImage", `${this.getDisplay("coverImage")}`)
 					.addOption("isbn", `${this.getDisplay("isbn")}`)
 					.addOption("review", `${this.getDisplay("review")}`)
 					.addOption("rating", `${this.getDisplay("rating")}`)

--- a/src/Shelf.ts
+++ b/src/Shelf.ts
@@ -66,7 +66,7 @@ export class Shelf {
 		let coverDownloadLocation = this.plugin.settings.coverDownloadLocation;
 
 		if (coverDownloadLocation === "")
-			coverDownloadLocation = this.plugin.settings.targetFolderPath;
+			coverDownloadLocation = `${this.plugin.settings.targetFolderPath}/cover`;
 
 		const fullPath = `${coverDownloadLocation}/${title}.jpg`;
 

--- a/src/Shelf.ts
+++ b/src/Shelf.ts
@@ -5,7 +5,7 @@ import Booksidian from "main";
 import { Notice } from "obsidian";
 import * as nodeFs from "fs";
 import { isAbsolute } from "path";
-import { writeBinaryFile } from "./helpers";
+import { pathExist, writeBinaryFile } from "./helpers";
 import { get } from "https";
 
 export class Shelf {
@@ -69,6 +69,8 @@ export class Shelf {
 			coverDownloadLocation = `${this.plugin.settings.targetFolderPath}/cover`;
 
 		const fullPath = `${coverDownloadLocation}/${title}.jpg`;
+
+		if (pathExist(fullPath)) return;
 
 		get(url, (response) => {
 			response.setEncoding("binary");

--- a/src/Shelf.ts
+++ b/src/Shelf.ts
@@ -5,6 +5,8 @@ import Booksidian from "main";
 import { Notice } from "obsidian";
 import * as nodeFs from "fs";
 import { isAbsolute } from "path";
+import { writeBinaryFile } from "./helpers";
+import { get } from "https";
 
 export class Shelf {
 	path: string;
@@ -48,11 +50,33 @@ export class Shelf {
 			const feed = await rssParser.parseURL(this.url);
 			feed.items.forEach(async (_book: GoodreadsBook) => {
 				const book = new Book(this.plugin, _book);
+
+				await this.fetchCoverImage(book.cover, book.title);
+
 				this.setBook(book);
 			});
 		} catch (e) {
 			console.warn(e);
 		}
+	}
+
+	private async fetchCoverImage(url: string, title: string) {
+		if (!this.plugin.settings.coverDownload) return;
+
+		let coverDownloadLocation = this.plugin.settings.coverDownloadLocation;
+
+		if (coverDownloadLocation === "")
+			coverDownloadLocation = this.plugin.settings.targetFolderPath;
+
+		const fullPath = `${coverDownloadLocation}/${title}.jpg`;
+
+		get(url, (response) => {
+			response.setEncoding("binary");
+
+			let rawData = new Uint16Array();
+			response.on("data", (chunk) => (rawData += chunk));
+			response.on("end", () => writeBinaryFile(fullPath, rawData));
+		});
 	}
 
 	public async createBookFiles(): Promise<void> {

--- a/src/Shelf.ts
+++ b/src/Shelf.ts
@@ -51,7 +51,10 @@ export class Shelf {
 			feed.items.forEach(async (_book: GoodreadsBook) => {
 				const book = new Book(this.plugin, _book);
 
-				await this.fetchCoverImage(book.cover, book.title);
+				book.coverImage = await this.fetchCoverImage(
+					book.cover,
+					book.title,
+				);
 
 				this.setBook(book);
 			});

--- a/src/Shelf.ts
+++ b/src/Shelf.ts
@@ -70,7 +70,7 @@ export class Shelf {
 
 		const fullPath = `${coverDownloadLocation}/${title}.jpg`;
 
-		if (pathExist(fullPath)) return;
+		if (pathExist(fullPath)) return fullPath;
 
 		get(url, (response) => {
 			response.setEncoding("binary");
@@ -79,6 +79,8 @@ export class Shelf {
 			response.on("data", (chunk) => (rawData += chunk));
 			response.on("end", () => writeBinaryFile(fullPath, rawData));
 		});
+
+		return fullPath;
 	}
 
 	public async createBookFiles(): Promise<void> {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,4 @@
-import { isAbsolute } from "path";
+import { isAbsolute, dirname } from "path";
 import * as nodeFs from "fs";
 import { App } from "obsidian";
 
@@ -14,5 +14,26 @@ export async function writeFile(path: string, content: string, app: App) {
 		} catch (error) {
 			console.log(`Error writing ${path}`, error);
 		}
+	}
+}
+
+export async function writeBinaryFile(
+	path: string,
+	content: Uint16Array,
+	overwrite = false,
+) {
+	const filePath = isAbsolute(path)
+		? path
+		: `${this.app.vault.adapter.basePath}/${path}`;
+
+	if (nodeFs.existsSync(filePath) && !overwrite) return;
+
+	const directory = dirname(filePath);
+	if (!nodeFs.existsSync(directory)) nodeFs.mkdirSync(directory);
+
+	try {
+		nodeFs.writeFileSync(filePath, content, { encoding: "binary" });
+	} catch (error) {
+		console.log(`Error writing ${filePath}`, error);
 	}
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -26,7 +26,7 @@ export async function writeBinaryFile(
 		? path
 		: `${this.app.vault.adapter.basePath}/${path}`;
 
-	if (nodeFs.existsSync(filePath) && !overwrite) return;
+	if (pathExist(filePath) && !overwrite) return;
 
 	const directory = dirname(filePath);
 	if (!nodeFs.existsSync(directory)) nodeFs.mkdirSync(directory);
@@ -36,4 +36,12 @@ export async function writeBinaryFile(
 	} catch (error) {
 		console.log(`Error writing ${filePath}`, error);
 	}
+}
+
+export function pathExist(path: string) {
+	const filePath = isAbsolute(path)
+		? path
+		: `${this.app.vault.adapter.basePath}/${path}`;
+
+	return nodeFs.existsSync(filePath);
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -17,16 +17,10 @@ export async function writeFile(path: string, content: string, app: App) {
 	}
 }
 
-export async function writeBinaryFile(
-	path: string,
-	content: Uint16Array,
-	overwrite = false,
-) {
+export async function writeBinaryFile(path: string, content: Uint16Array) {
 	const filePath = isAbsolute(path)
 		? path
 		: `${this.app.vault.adapter.basePath}/${path}`;
-
-	if (pathExist(filePath) && !overwrite) return;
 
 	const directory = dirname(filePath);
 	if (!nodeFs.existsSync(directory)) nodeFs.mkdirSync(directory);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,18 @@
+import { isAbsolute } from "path";
+import * as nodeFs from "fs";
+import { App } from "obsidian";
+
+export async function writeFile(path: string, content: string, app: App) {
+	if (isAbsolute(path)) {
+		nodeFs.writeFile(path, content, (error) => {
+			if (error) console.log(`Error writing ${path}`, error);
+		});
+	} else {
+		try {
+			const fs = app.vault.adapter;
+			await fs.write(path, content);
+		} catch (error) {
+			console.log(`Error writing ${path}`, error);
+		}
+	}
+}


### PR DESCRIPTION
This PR adds settings to download a books cover image to a specified folder.

Download is defaulted to `false`.
Download folder is defaulted to `Target Folder/cover`

Changes:
- **feat(SettingsTab): added settings entry for enabling download of book covers**
- **feat(SettingsTab): added entry for setting the download path for the cover images**
- **feat(helpers.writeFile): extracted writeFile to helpers module**
- **feat(helpers): added writeBinaryFile**
- **feat(Shelf): added fetchCoverImage)**
- **chore: made the default download folder be under "Target Folder/cover" instead of directly in "Target Folder"**
- **chore(helpers): extracted fileExist check to separate function**
- **chore(helpers/writeBinaryFile): removed overwrite prop**
- **chore(fetchCoverImage): only download cover if it's missing**
- **chore(fetchCoverImage): return image path**
- **feat(GoodreadsBook): added image_path**
- **feat(Book): added coverImage property**
- **feat(Shelf): populate coverImage as a result of fetching the cover image**
- **feat(Settings): added option to add coverImage to frontmatter**
- **chore(Settings): fixed description**
- **feat(Settings): made it so that coverImage defaults to be a link in frontmatter**
