### PR TITLE
Add field `dateCreated`

### DIFF
--- a/const/goodreads.ts
+++ b/const/goodreads.ts
@@ -10,6 +10,7 @@ export interface GoodreadsBook {
 	average_rating: string;
 	user_read_at: string;
 	user_date_added: string;
+	user_date_created: string;
 	book_published: string;
 	identifiers: Identifiers;
 	content: string;

--- a/const/rssParser.ts
+++ b/const/rssParser.ts
@@ -16,6 +16,7 @@ export const rssParser = new Parser({
 			"average_rating",
 			"user_read_at",
 			"user_date_added",
+			"user_date_created",
 			"book_published",
 			["book", "identifiers"],
 			"user_shelves",

--- a/src/Book.ts
+++ b/src/Book.ts
@@ -26,6 +26,7 @@ export class Book {
 	avgRating: number;
 	shelves: string[];
 	dateAdded: string;
+	dateCreated: string;
 	dateRead: string;
 	datePublished: string;
 	cover: string;
@@ -48,6 +49,7 @@ export class Book {
 		this.rating = parseInt(book.user_rating) || 0;
 		this.avgRating = parseFloat(book.average_rating) || 0;
 		this.dateAdded = this.parseDate(book.user_date_added);
+		this.dateCreated = this.parseDate(book.user_date_created);
 		this.dateRead = this.parseDate(book.user_read_at);
 		this.datePublished = this.parseDate(book.book_published);
 		this.cover = book.image_url;

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -268,6 +268,10 @@ export class Settings extends PluginSettingTab {
 					.addOption("rating", `${this.getDisplay("rating")}`)
 					.addOption("avgRating", `${this.getDisplay("avgRating")}`)
 					.addOption("dateAdded", `${this.getDisplay("dateAdded")}`)
+					.addOption(
+						"dateCreated",
+						`${this.getDisplay("dateCreated")}`,
+					)
 					.addOption("dateRead", `${this.getDisplay("dateRead")}`)
 					.addOption(
 						"datePublished",


### PR DESCRIPTION
This PR adds the field `dateCrated` which parses and exposes the field `user_date_created` from goodreads.
