### PR TITLE
Fix: Shared covers when Download cover is enabled

### DIFF
--- a/src/Shelf.ts
+++ b/src/Shelf.ts
@@ -53,7 +53,7 @@ export class Shelf {
 
 				book.coverImage = await this.fetchCoverImage(
 					book.cover,
-					book.title,
+					book.id,
 				);
 
 				this.setBook(book);


### PR DESCRIPTION
This PR changes the naming scheme for the downloaded covers to always be the book id.
This makes it so that the covers are still unique and they will not need to be downloaded again if the user decides to change the Naming Pattern for the books themselves.
