### PR TITLE
Fix: Use vault root folder when target folder is not specified

### DIFF
--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -61,10 +61,12 @@ export class Settings extends PluginSettingTab {
 					.setPlaceholder("Vault root")
 					.setValue(this.plugin.settings.targetFolderPath)
 					.onChange(async (value) => {
-						this.plugin.settings.targetFolderPath = value.replace(
-							/[\\/]+$/g, // matches any trailing slashes
-							"",
-						);
+						this.plugin.settings.targetFolderPath = value
+							.replace(
+								/[\\/]+$/g, // matches any trailing slashes
+								"",
+							)
+							.trim();
 						await this.plugin.saveSettings();
 					}),
 			);

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -58,7 +58,7 @@ export class Settings extends PluginSettingTab {
 			)
 			.addText((text) =>
 				text
-					.setPlaceholder("")
+					.setPlaceholder("Vault root")
 					.setValue(this.plugin.settings.targetFolderPath)
 					.onChange(async (value) => {
 						this.plugin.settings.targetFolderPath = value.replace(

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -54,7 +54,7 @@ export class Settings extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Target Folder")
 			.setDesc(
-				"Path to where to store the book notes. Can be either a relative path within the vault, or absolute outside of the vault. If you leave this empty, the books will be created in the root directory.",
+				"Path to where to store the book notes. Can be either a relative path within the vault, or absolute outside of the vault. If you leave this empty, the books will be created in the root of the vault.",
 			)
 			.addText((text) =>
 				text

--- a/src/Shelf.ts
+++ b/src/Shelf.ts
@@ -17,7 +17,9 @@ export class Shelf {
 		public plugin: Booksidian,
 		public shelfName: string,
 	) {
-		this.path = `${plugin.settings.targetFolderPath}`;
+		const targetFolder = plugin.settings.targetFolderPath;
+		this.path = targetFolder === "" ? "./" : targetFolder;
+
 		this.url = `${plugin.settings.goodreadsBaseUrl}${shelfName.toLocaleLowerCase()}`;
 	}
 


### PR DESCRIPTION
This PR makes it so that **Target Folder** defaults to the root of the vault.
This seem to have been original the intent of the setting but seem like it wasn't implemented properly as it tried to write to the root of the drive instead (Windows = `c:\`, Linux/Mac = `/`), which it is not permitted to do.

Example from Linux when setting is empty:
```
Error writing /Martha Wells - Artificial Condition.md Error: EACCES: permission denied, open '/Martha Wells - Artificial Condition.md'
```