### PR TITLE
Fix: cover location when target folder is not specified

### DIFF
--- a/src/Shelf.ts
+++ b/src/Shelf.ts
@@ -71,7 +71,7 @@ export class Shelf {
 		let coverDownloadLocation = this.plugin.settings.coverDownloadLocation;
 
 		if (coverDownloadLocation === "")
-			coverDownloadLocation = `${this.plugin.settings.targetFolderPath}/cover`;
+			coverDownloadLocation = `${this.plugin.settings.targetFolderPath || "."}/cover`;
 
 		const fullPath = `${coverDownloadLocation}/${title}.jpg`;
 


### PR DESCRIPTION
This PR fixes the download folder path for cover images when the target folder setting is not set.

Fix missing from #66 