### PR TITLE
Assign book to "read" shelf if it's in the "read" shelf while readDate is missing

### DIFF
--- a/src/Shelf.ts
+++ b/src/Shelf.ts
@@ -62,6 +62,14 @@ export class Shelf {
 						book.cover,
 						book.id,
 					);
+
+					// If we're currently explicitly checking the `read` shelf, we add it
+					if (
+						this.shelfName === "read" &&
+						!book.shelves.contains("read")
+					)
+						book.shelves.push("read");
+
 					this.setBook(book);
 				}
 				page++;


### PR DESCRIPTION
This has to be done after the Book constructor has finished since the current shelf we're iterating over only exists in the `fetchGoodreadsFeed` function and the shelves is populated during the construction.

This will only assign books to the "read" shelf if the current shelf we're iterating over is the "read" shelf and that it was not added to this shelf during the constructor.