### PR TITLE
feat: add frontmatter-only overwrite support

### DIFF
--- a/const/settings.ts
+++ b/const/settings.ts
@@ -7,6 +7,7 @@ export interface BooksidianSettings {
 	bodyString: string;
 	frequency: string;
 	overwrite: boolean;
+	overwritePreserveBody: boolean;
 	coverDownload: boolean;
 	coverDownloadLocation: string;
 }
@@ -24,6 +25,7 @@ export const DEFAULT_SETTINGS: BooksidianSettings = {
 	bodyString: "# {{title}}\n\nauthor::[[{{author}}]]",
 	frequency: "0", // manual
 	overwrite: false,
+	overwritePreserveBody: true,
 	coverDownload: false,
 	coverDownloadLocation: "",
 };

--- a/src/Book.ts
+++ b/src/Book.ts
@@ -2,7 +2,7 @@ import { CurrentYAML } from "const/settings";
 import { GoodreadsBook } from "const/goodreads";
 import Booksidian from "main";
 import { Body } from "./Body";
-import { Frontmatter } from "./Frontmatter";
+import { Frontmatter, stripFrontmatter } from "./Frontmatter";
 import { writeFile } from "./helpers";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -112,6 +112,19 @@ export class Book {
 
 		const file = this.plugin.app.vault.getFileByPath(fullPath);
 		if (file && !this.plugin.settings.overwrite) return;
+
+		if (file && this.plugin.settings.overwritePreserveBody) {
+			const existing = await this.plugin.app.vault.read(file);
+			const newFrontmatter = this.getFrontMatter(
+				this.plugin.settings.frontmatterDictionary,
+			);
+			writeFile(
+				fullPath,
+				newFrontmatter + stripFrontmatter(existing),
+				this.plugin.app,
+			);
+			return;
+		}
 
 		const bookContent = book.getContent();
 

--- a/src/Frontmatter.ts
+++ b/src/Frontmatter.ts
@@ -50,3 +50,22 @@ export class Frontmatter {
 		return yaml.dump(output);
 	}
 }
+
+/**
+ * Return `content` with its leading frontmatter block removed. If there is
+ * no leading `---` fence, or the opening fence has no matching closing
+ * fence (malformed), `content` is returned unchanged so body data is never
+ * destroyed.
+ */
+export function stripFrontmatter(content: string): string {
+	const opening = FRONTMATTER_LINES + "\n";
+	if (!content.startsWith(opening)) return content;
+
+	const lines = content.split("\n");
+	for (let i = 1; i < lines.length; i++) {
+		if (lines[i] === FRONTMATTER_LINES) {
+			return lines.slice(i + 1).join("\n");
+		}
+	}
+	return content;
+}

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -149,6 +149,8 @@ export class Settings extends PluginSettingTab {
 				});
 			});
 
+		let preserveBodySetting: Setting;
+
 		new Setting(containerEl)
 			.setName("Overwrite")
 			.setDesc(
@@ -160,8 +162,33 @@ export class Settings extends PluginSettingTab {
 				toggle.onChange((newValue) => {
 					this.plugin.settings.overwrite = newValue;
 					this.plugin.saveSettings();
+					preserveBodySetting.settingEl.toggleClass(
+						"is-hidden",
+						!newValue,
+					);
 				});
 			});
+
+		preserveBodySetting = new Setting(containerEl)
+			.setName("Preserve note body")
+			.setDesc(
+				"When overwriting, only update the YAML frontmatter and keep the note body untouched. Useful for preserving manual edits while still picking up dynamic Goodreads fields like dateRead and shelves.",
+			)
+			.addToggle((toggle) => {
+				toggle.setValue(this.plugin.settings.overwritePreserveBody);
+
+				toggle.onChange((newValue) => {
+					this.plugin.settings.overwritePreserveBody = newValue;
+					this.plugin.saveSettings();
+				});
+			});
+		preserveBodySetting.settingEl.addClass(
+			"booksidian-plugin__sub-setting",
+		);
+		preserveBodySetting.settingEl.toggleClass(
+			"is-hidden",
+			!this.plugin.settings.overwrite,
+		);
 
 		containerEl.createEl("h4", { text: "Book covers" });
 

--- a/styles.css
+++ b/styles.css
@@ -5,3 +5,12 @@
 .booksidian-plugin__settings input, textarea, select {
 	min-width: 200px;
 }
+
+.booksidian-plugin__sub-setting {
+	padding-left: 2.5em;
+	border-top: none;
+}
+
+.booksidian-plugin__sub-setting.is-hidden {
+	display: none;
+}

--- a/test/FrontmatterTest.ts
+++ b/test/FrontmatterTest.ts
@@ -1,0 +1,34 @@
+import { stripFrontmatter } from "src/Frontmatter";
+
+describe("stripFrontmatter", () => {
+	test("file with frontmatter and body: returns body byte-identical", () => {
+		const existing = "---\ntitle: old\n---\n# Heading\n\nMy notes.\n";
+		expect(stripFrontmatter(existing)).toBe("# Heading\n\nMy notes.\n");
+	});
+
+	test("file with frontmatter only (no body): returns empty string", () => {
+		expect(stripFrontmatter("---\ntitle: old\n---\n")).toBe("");
+	});
+
+	test("file with no frontmatter: returns content unchanged", () => {
+		const existing = "Just some body text.\n";
+		expect(stripFrontmatter(existing)).toBe(existing);
+	});
+
+	test("empty file: returns empty string", () => {
+		expect(stripFrontmatter("")).toBe("");
+	});
+
+	test("body containing --- horizontal rules: only leading frontmatter block is stripped", () => {
+		const existing =
+			"---\ntitle: old\n---\nIntro\n\n---\n\nAfter rule\n";
+		expect(stripFrontmatter(existing)).toBe(
+			"Intro\n\n---\n\nAfter rule\n",
+		);
+	});
+
+	test("malformed: opening --- with no closing --- returns content unchanged", () => {
+		const existing = "---\ntitle: old\nno closing fence here\n";
+		expect(stripFrontmatter(existing)).toBe(existing);
+	});
+});


### PR DESCRIPTION
Addresses https://github.com/MichaBrugger/booksidian_plugin/issues/74


Adds a "preserve body" setting to the overwrite functionality. Configurable via a toggle that shows up when "Overwrite" is enabled.

Tested locally.

Word of caution: GoodReads caches the RSS feed so quick changes for testing might send you chasing ghost bugs.

<img width="815" height="270" alt="image" src="https://github.com/user-attachments/assets/00ebe48d-79cb-4535-b752-9c9719a29ebc" />
---
<img width="799" height="303" alt="image" src="https://github.com/user-attachments/assets/b51a9eac-6357-4cb9-a6de-1f05ba37325d" />
